### PR TITLE
Updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,5 @@ group :test do
   gem 'byebug'
   gem 'webmock'
   gem 'vcr'
+  gem 'pry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,14 +66,14 @@ GEM
       multi_json (~> 1.10)
     memoist (0.13.0)
     mime-types (2.6.1)
-    mini_portile (0.6.2)
+    mini_portile2 (2.3.0)
     minitest (5.8.3)
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     newrelic_rpm (3.14.1.311)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     oauth (0.4.7)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
@@ -83,8 +83,8 @@ GEM
       rack (~> 1.2)
     octokit (4.1.0)
       sawyer (~> 0.6.0, >= 0.5.3)
-    rack (1.6.4)
-    rack-protection (1.5.3)
+    rack (1.6.9)
+    rack-protection (1.5.5)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -152,5 +152,8 @@ DEPENDENCIES
   vcr
   webmock
 
+RUBY VERSION
+   ruby 2.2.3p173
+
 BUNDLED WITH
-   1.10.6
+   1.16.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
       capybara
       httpclient (~> 2.2)
       multi_json (~> 1.3)
+    coderay (1.1.2)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
@@ -65,6 +66,7 @@ GEM
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     memoist (0.13.0)
+    method_source (0.9.0)
     mime-types (2.6.1)
     mini_portile2 (2.3.0)
     minitest (5.8.3)
@@ -83,6 +85,9 @@ GEM
       rack (~> 1.2)
     octokit (4.1.0)
       sawyer (~> 0.6.0, >= 0.5.3)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rack (1.6.9)
     rack-protection (1.5.5)
       rack
@@ -143,6 +148,7 @@ DEPENDENCIES
   google_drive
   newrelic_rpm
   octokit (~> 4.0)
+  pry
   rake
   redis
   rspec

--- a/lib/find_channel.rb
+++ b/lib/find_channel.rb
@@ -3,8 +3,15 @@ require_relative 'slack_notifier'
 class FindChannel
   def self.with(channel)
     notifier = SlackNotifier.new({team: 'makersstudents', channel: slackified_channel(channel)})
-    # If the channel does not exist, the error message is 'Invalid channel specified'
-    notifier.notify('') != "Invalid channel specified"
+
+    # This relies on SlackNotifier to first check if channel exists, and then to check if message is empty
+
+    begin
+      notifier.notify('')
+    rescue SlackNotifications::SlackNotificationError => e
+      return true if e.code == '500'
+      return false if e.code == '404'
+    end
   end
 
   private

--- a/lib/slack_notification_errors.rb
+++ b/lib/slack_notification_errors.rb
@@ -1,0 +1,26 @@
+module SlackNotifications
+  class SlackNotificationError < StandardError
+    attr_reader :code, :body
+
+    def initialize(code, body)
+      @code = code
+      @body = body
+    end
+
+    def message
+      "#{@code}: #{@body}"
+    end
+  end
+
+  class DefaultError < SlackNotificationError
+    def message
+      "Please update slack_notifier in /lib with this error: #{@code}: #{@body}"
+    end
+  end
+
+  class ChannelNotFoundError < SlackNotificationError
+  end
+
+  class NoTextError < SlackNotificationError
+  end
+end

--- a/lib/slack_notifier.rb
+++ b/lib/slack_notifier.rb
@@ -1,10 +1,16 @@
 require_relative 'notification_record'
+require_relative 'slack_notification_errors'
 
 class SlackNotifier
   def self.notify(message)
   end
 
   DEFAULT_USERNAME = 'mechacoach'
+  ERRORS = {
+    '404' => SlackNotifications::ChannelNotFoundError,
+    '500' => SlackNotifications::NoTextError
+  }
+
   attr_reader :client, :channel, :username
 
   def initialize(client_class: Slack::Notifier, team: 'makersacademy', channel: '#testing')
@@ -14,15 +20,21 @@ class SlackNotifier
   end
 
   def notify(message = default_message)
-    if client.ping(message).code == '500'
-      return client.ping(message).body
-    end
+    res = client.ping(message)
+
+    raise error(res.code, res.body) unless res.code == '200'
+
     notification = { channel: channel, message: message }
     NotificationRecord.store(notification)
+
     :notified
   end
 
   private
+
+  def error(code, msg)
+    ERRORS.fetch(code, SlackNotifications::DefaultError).new(code, msg)
+  end
 
   def config(channel)
     {

--- a/spec/features/pair_release_spec.rb
+++ b/spec/features/pair_release_spec.rb
@@ -3,19 +3,19 @@ feature 'Pair release slack notification' do
   before { allow_any_instance_of(SlackNotifier).to receive(:notify) }
 
   context 'for one cohort "test2016"' do
-    let(:assignments_source) do 
+    let(:assignments_source) do
       [
         [['jon', 'andrew'], ['bob', 'phil']],
         [['jon', 'phil'], ['bob', 'andrew']],
         [['jon', 'bob'], ['andrew', 'phil']]
-      ] 
+      ]
     end
 
     let(:params) { { cohort: 'test2016', release_time: Time.now } }
 
     before do
       PairAssignments.repo.set("test2016_pairs", assignments_source.to_json)
-      PairAssignments.repo.set("test2016_index", nil)
+      PairAssignments.repo.set("test2016_index", 0)
     end
 
     scenario 'request to "/pairs/release" releases a pair assignment to slack' do
@@ -40,15 +40,15 @@ feature 'Pair release slack notification' do
   end
 
   context 'for another cohort "test2017"' do
-    let(:assignments_source) do 
-      [ [['sarah', 'suleiman'], ['xeno', 'ermintrude']] ] 
+    let(:assignments_source) do
+      [ [['sarah', 'suleiman'], ['xeno', 'ermintrude']] ]
     end
 
     let(:params) { { cohort: 'test2017', release_time: Time.now } }
 
     before do
       PairAssignments.repo.set("test2017_pairs", assignments_source.to_json)
-      PairAssignments.repo.set("test2017_index", nil)
+      PairAssignments.repo.set("test2017_index", 0)
     end
 
     scenario 'requests to "/pairs/release" releases a pair assignment to slack' do

--- a/spec/find_channel_spec.rb
+++ b/spec/find_channel_spec.rb
@@ -22,7 +22,7 @@ describe FindChannel do
   private
 
   def existing_channel
-    'october2015'
+    'testing'
   end
 
   def non_existent_channel

--- a/spec/fixtures/vcr_cassettes/check_cohort_channel_name.yml
+++ b/spec/fixtures/vcr_cassettes/check_cohort_channel_name.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://hooks.slack.com/services/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
+    uri: https://hooks.slack.com/services/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
     body:
       encoding: US-ASCII
       string: payload=%7B%22channel%22%3A%22%23october2015%22%2C%22username%22%3A%22mechacoach%22%2C%22icon_emoji%22%3A%22%3Atophat%3A%22%2C%22text%22%3A%22%22%7D
@@ -20,70 +20,37 @@ http_interactions:
       code: 500
       message: Server Error
     headers:
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Security-Policy:
-      - referrer no-referrer;
       Content-Type:
       - text/html
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
       Date:
-      - Thu, 10 Dec 2015 12:25:40 GMT
+      - Wed, 11 Apr 2018 13:13:58 GMT
       Server:
       - Apache
+      X-Slack-Backend:
+      - h
+      Referrer-Policy:
+      - no-referrer
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       X-Frame-Options:
       - SAMEORIGIN
-      Content-Length:
-      - '17'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: No text specified
-    http_version: 
-  recorded_at: Thu, 10 Dec 2015 12:25:41 GMT
-- request:
-    method: post
-    uri: https://hooks.slack.com/services/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
-    body:
-      encoding: US-ASCII
-      string: payload=%7B%22channel%22%3A%22%23october2015%22%2C%22username%22%3A%22mechacoach%22%2C%22icon_emoji%22%3A%22%3Atophat%3A%22%2C%22text%22%3A%22%22%7D
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 500
-      message: Server Error
-    headers:
       Access-Control-Allow-Origin:
       - "*"
-      Content-Security-Policy:
-      - referrer no-referrer;
-      Content-Type:
-      - text/html
-      Date:
-      - Thu, 10 Dec 2015 12:25:41 GMT
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '17'
-      Connection:
-      - keep-alive
+      X-Via:
+      - haproxy-www-0dty
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 b4931728b870992723090d6ce0d2daa5.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - DbwQgl4875W5wR1GUWYWh8PM56edFrTqrkNhcuhddI9v-3UKp8y-og==
     body:
       encoding: UTF-8
-      string: No text specified
+      string: missing_text_or_fallback_or_attachments
     http_version: 
-  recorded_at: Thu, 10 Dec 2015 12:25:41 GMT
+  recorded_at: Wed, 11 Apr 2018 13:13:58 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/check_missing_cohort_channel_name.yml
+++ b/spec/fixtures/vcr_cassettes/check_missing_cohort_channel_name.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://hooks.slack.com/services/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
+    uri: https://hooks.slack.com/services/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
     body:
       encoding: US-ASCII
       string: payload=%7B%22channel%22%3A%22%23october+2015%22%2C%22username%22%3A%22mechacoach%22%2C%22icon_emoji%22%3A%22%3Atophat%3A%22%2C%22text%22%3A%22%22%7D
@@ -17,73 +17,40 @@ http_interactions:
       - application/x-www-form-urlencoded
   response:
     status:
-      code: 500
-      message: Server Error
+      code: 404
+      message: Not Found
     headers:
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Security-Policy:
-      - referrer no-referrer;
       Content-Type:
       - text/html
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
       Date:
-      - Thu, 10 Dec 2015 12:25:36 GMT
+      - Wed, 11 Apr 2018 13:14:21 GMT
       Server:
       - Apache
+      X-Slack-Backend:
+      - h
+      Referrer-Policy:
+      - no-referrer
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       X-Frame-Options:
       - SAMEORIGIN
-      Content-Length:
-      - '25'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: Invalid channel specified
-    http_version: 
-  recorded_at: Thu, 10 Dec 2015 12:25:36 GMT
-- request:
-    method: post
-    uri: https://hooks.slack.com/services/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
-    body:
-      encoding: US-ASCII
-      string: payload=%7B%22channel%22%3A%22%23october+2015%22%2C%22username%22%3A%22mechacoach%22%2C%22icon_emoji%22%3A%22%3Atophat%3A%22%2C%22text%22%3A%22%22%7D
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 500
-      message: Server Error
-    headers:
       Access-Control-Allow-Origin:
       - "*"
-      Content-Security-Policy:
-      - referrer no-referrer;
-      Content-Type:
-      - text/html
-      Date:
-      - Thu, 10 Dec 2015 12:25:36 GMT
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '25'
-      Connection:
-      - keep-alive
+      X-Via:
+      - haproxy-www-i8ac
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 0f5204fd322d4632134ce901aa024a61.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - O-UfrbqUJrwFaVl47_HHWlzpyD1QJKY4U7KCP8Jx5zIUz4idaxlTwg==
     body:
       encoding: UTF-8
-      string: Invalid channel specified
+      string: channel_not_found
     http_version: 
-  recorded_at: Thu, 10 Dec 2015 12:25:37 GMT
+  recorded_at: Wed, 11 Apr 2018 13:14:21 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/existing_channel.yml
+++ b/spec/fixtures/vcr_cassettes/existing_channel.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://hooks.slack.com/services/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
+    uri: https://hooks.slack.com/services/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
     body:
       encoding: US-ASCII
-      string: payload=%7B%22channel%22%3A%22%23october2015%22%2C%22username%22%3A%22mechacoach%22%2C%22icon_emoji%22%3A%22%3Atophat%3A%22%2C%22text%22%3A%22%22%7D
+      string: payload=%7B%22channel%22%3A%22%23testing%22%2C%22username%22%3A%22mechacoach%22%2C%22icon_emoji%22%3A%22%3Atophat%3A%22%2C%22text%22%3A%22%22%7D
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -20,70 +20,37 @@ http_interactions:
       code: 500
       message: Server Error
     headers:
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Security-Policy:
-      - referrer no-referrer;
       Content-Type:
       - text/html
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
       Date:
-      - Thu, 10 Dec 2015 12:36:10 GMT
+      - Wed, 11 Apr 2018 13:08:33 GMT
       Server:
       - Apache
+      X-Slack-Backend:
+      - h
+      Referrer-Policy:
+      - no-referrer
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       X-Frame-Options:
       - SAMEORIGIN
-      Content-Length:
-      - '17'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: No text specified
-    http_version: 
-  recorded_at: Thu, 10 Dec 2015 12:36:10 GMT
-- request:
-    method: post
-    uri: https://hooks.slack.com/services/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
-    body:
-      encoding: US-ASCII
-      string: payload=%7B%22channel%22%3A%22%23october2015%22%2C%22username%22%3A%22mechacoach%22%2C%22icon_emoji%22%3A%22%3Atophat%3A%22%2C%22text%22%3A%22%22%7D
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 500
-      message: Server Error
-    headers:
       Access-Control-Allow-Origin:
       - "*"
-      Content-Security-Policy:
-      - referrer no-referrer;
-      Content-Type:
-      - text/html
-      Date:
-      - Thu, 10 Dec 2015 12:36:10 GMT
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '17'
-      Connection:
-      - keep-alive
+      X-Via:
+      - haproxy-www-rju6
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 a59248a3f35122c2ec3af07e422e20d5.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - G8zQLaZxt-PVPCigMhHy_HNK_g8PRzTbnJh6X7FzaNQQAZCbJ-srkw==
     body:
       encoding: UTF-8
-      string: No text specified
+      string: missing_text_or_fallback_or_attachments
     http_version: 
-  recorded_at: Thu, 10 Dec 2015 12:36:11 GMT
+  recorded_at: Wed, 11 Apr 2018 13:08:34 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/not_existing_channel.yml
+++ b/spec/fixtures/vcr_cassettes/not_existing_channel.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://hooks.slack.com/services/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
+    uri: https://hooks.slack.com/services/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
     body:
       encoding: US-ASCII
       string: payload=%7B%22channel%22%3A%22%23october+2015%22%2C%22username%22%3A%22mechacoach%22%2C%22icon_emoji%22%3A%22%3Atophat%3A%22%2C%22text%22%3A%22%22%7D
@@ -17,73 +17,40 @@ http_interactions:
       - application/x-www-form-urlencoded
   response:
     status:
-      code: 500
-      message: Server Error
+      code: 404
+      message: Not Found
     headers:
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Security-Policy:
-      - referrer no-referrer;
       Content-Type:
       - text/html
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
       Date:
-      - Thu, 10 Dec 2015 12:36:11 GMT
+      - Wed, 11 Apr 2018 13:07:25 GMT
       Server:
       - Apache
+      X-Slack-Backend:
+      - h
+      Referrer-Policy:
+      - no-referrer
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       X-Frame-Options:
       - SAMEORIGIN
-      Content-Length:
-      - '25'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: Invalid channel specified
-    http_version: 
-  recorded_at: Thu, 10 Dec 2015 12:36:11 GMT
-- request:
-    method: post
-    uri: https://hooks.slack.com/services/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
-    body:
-      encoding: US-ASCII
-      string: payload=%7B%22channel%22%3A%22%23october+2015%22%2C%22username%22%3A%22mechacoach%22%2C%22icon_emoji%22%3A%22%3Atophat%3A%22%2C%22text%22%3A%22%22%7D
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 500
-      message: Server Error
-    headers:
       Access-Control-Allow-Origin:
       - "*"
-      Content-Security-Policy:
-      - referrer no-referrer;
-      Content-Type:
-      - text/html
-      Date:
-      - Thu, 10 Dec 2015 12:36:11 GMT
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '25'
-      Connection:
-      - keep-alive
+      X-Via:
+      - haproxy-www-x2wz
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 d8092a8d54d8fece6c4843b62f11e865.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 7p9BIR9K40pAerSQfBW9hgC2l9SCO4zrSBFwq1ySchJm-8KTHUWAHw==
     body:
       encoding: UTF-8
-      string: Invalid channel specified
+      string: channel_not_found
     http_version: 
-  recorded_at: Thu, 10 Dec 2015 12:36:12 GMT
+  recorded_at: Wed, 11 Apr 2018 13:07:25 GMT
 recorded_with: VCR 2.9.3

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'capybara/json'
 # Add Sinatra integration using Capybara
 Capybara.app = MechacoachServer
 
+require 'pry'
 require 'vcr'
 require 'webmock/rspec'
 


### PR DESCRIPTION
Problem 1. when run locally, some tests were failing
Problem 2. gems needed updating
Problem 3. A webhook url was updated
Problem 4. Explicitly setting a redis key value as nil in tests, breaks the `.incr` method which looks for an integer

As a result I've changed a bit of the implementation that wraps around the `slack-notification` gem to be a bit more resilient to change and rerecorded the cassettes.